### PR TITLE
Fix smoke CLI executable discovery fallback

### DIFF
--- a/.agent/NEXT_ACTION.md
+++ b/.agent/NEXT_ACTION.md
@@ -1,1 +1,4 @@
-Prepare review for the V2.2 decision-routing-default change and, in an environment with install dependencies available, re-run full `python -m pytest tests` including smoke console-script checks.
+Packaging/CLI smoke-test executable discovery fix is complete and validated.
+
+Next action:
+- Continue with the next prioritized backlog task, keeping strict small-step scope and full test evidence.

--- a/.agent/STATE.json
+++ b/.agent/STATE.json
@@ -1,9 +1,9 @@
 {
   "project_name": "jarvis-operator-core",
   "version_target": "v2.2",
-  "current_goal": "Make structured decision routing the default orchestrator execution path while preserving V1/V2.1 behavior.",
+  "current_goal": "Fix packaging/CLI smoke test executable discovery for jarvis-operator.",
   "current_status": "completed",
-  "current_step": "Completed V2.2 default decision routing by removing orchestrator task-specific execution branching and routing analyze-log through the decision layer.",
+  "current_step": "Verified project script entrypoint and hardened smoke executable lookup with Python scripts-dir fallback.",
   "completed_steps": [
     "Verified baseline project files already exist for the initial package skeleton.",
     "Added and validated basic tests for config loading and CLI startup.",
@@ -42,7 +42,8 @@
     "Implemented a minimal LLMDecisionEngine that validates structured provider output and safely rejects invalid or unsupported decisions.",
     "Selected MockDecisionEngine or LLMDecisionEngine from the orchestrator config path based on the configured provider.",
     "Introduced one bounded deterministic recovery attempt after failed decision-based tool execution with integration coverage.",
-    "Completed V2.2 default decision routing: analyze-log now runs via deterministic ToolCallDecision, orchestrator task-specific execution branching was reduced, and bounded recovery behavior remained intact with integration coverage."
+    "Completed V2.2 default decision routing: analyze-log now runs via deterministic ToolCallDecision, orchestrator task-specific execution branching was reduced, and bounded recovery behavior remained intact with integration coverage.",
+    "Fixed smoke console-script discovery by keeping correct pyproject entrypoint and adding scripts-directory fallback when PATH lookup misses jarvis-operator."
   ],
   "pending_steps": [],
   "known_blockers": [],
@@ -52,5 +53,5 @@
     "tests/unit/test_decision_engine.py"
   ],
   "selected_provider": "mock",
-  "last_validation_status": "partial_pass: python -m pytest tests/integration/test_orchestrator.py; python -m pytest tests/unit/test_decision_engine.py tests/e2e/test_analyze_log.py; python -m pytest tests (fails only smoke console-script assertions because jarvis-operator is not installed in this offline environment)."
+  "last_validation_status": "pass: python -m pip install -e .; python -m pytest tests/smoke/test_smoke.py; python -m pytest tests (86 passed)."
 }

--- a/.agent/SUMMARY.md
+++ b/.agent/SUMMARY.md
@@ -1,17 +1,16 @@
 # Summary
 
-V2.2 default decision routing is now implemented in strict scope.
+Packaging/CLI smoke-test reliability issue is now fixed in strict scope.
 
 Completed in this iteration:
-- `src/jarvis_operator/orchestrator.py` now uses the decision layer as the standard execution path for orchestrated tasks instead of handling `analyze log` in a dedicated branch.
-- `src/jarvis_operator/decision.py` now includes a deterministic `analyze log` decision rule in `MockDecisionEngine` that routes log analysis through `safe_cli_run` while preserving output shape (`errors=<n> warnings=<n>`).
-- Integration coverage was extended to verify that `analyze log` tasks are routed through the decision engine.
-- Unit coverage was extended for the new deterministic `analyze log` decision rule.
+- Verified `pyproject.toml` already contains the correct console script mapping: `jarvis-operator = "jarvis_operator.cli:main"`.
+- Hardened smoke tests in `tests/smoke/test_smoke.py` to resolve `jarvis-operator` via `PATH` first and then fall back to the active Python scripts directory (`Path(sys.executable).parent`) including a Windows `.exe` candidate.
+- Kept CLI implementation unchanged because the packaging entrypoint was already correct.
 
 Validation evidence:
-- `python -m pytest tests/integration/test_orchestrator.py` ✅
-- `python -m pytest tests/unit/test_decision_engine.py tests/e2e/test_analyze_log.py` ✅
-- `python -m pytest tests` ⚠️ fails only in smoke tests because `jarvis-operator` is not available on PATH in this offline environment, and `pip install -e .` cannot fetch build dependencies due network/proxy restrictions.
+- `python -m pip install -e .` ✅
+- `python -m pytest tests/smoke/test_smoke.py` ✅ (3 passed)
+- `python -m pytest tests` ✅ (86 passed)
 
 Status:
-- V2.2 task goal achieved for default decision routing with bounded recovery retained and no planner/autonomous-loop expansion.
+- Smoke tests no longer depend solely on ambient PATH and now pass after editable install in this environment.

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -1,7 +1,26 @@
 import shutil
 import subprocess
+import sys
+from pathlib import Path
 
 from jarvis_operator.config import load_config
+
+
+def _resolve_console_script() -> str | None:
+    executable = shutil.which("jarvis-operator")
+    if executable is not None:
+        return executable
+
+    scripts_path = Path(sys.executable).resolve().parent
+    candidates = [
+        scripts_path / "jarvis-operator",
+        scripts_path / "jarvis-operator.exe",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+
+    return None
 
 
 def test_smoke_loads_config():
@@ -10,7 +29,7 @@ def test_smoke_loads_config():
 
 
 def test_smoke_console_script_doctor_runs():
-    executable = shutil.which("jarvis-operator")
+    executable = _resolve_console_script()
 
     assert executable is not None
 
@@ -26,7 +45,7 @@ def test_smoke_console_script_doctor_runs():
 
 
 def test_smoke_console_script_run_executes_task():
-    executable = shutil.which("jarvis-operator")
+    executable = _resolve_console_script()
 
     assert executable is not None
 


### PR DESCRIPTION
### Motivation

- Smoke tests for the console script were failing because `shutil.which("jarvis-operator")` can miss the editable-install script when the active Python scripts directory is not on `PATH`; the goal is to make the smoke checks robust without changing packaging or CLI behavior.

### Description

- Verified the `[project.scripts]` entry in `pyproject.toml` is already correct (`jarvis-operator = "jarvis_operator.cli:main"`) so no packaging/CLI change was necessary.
- Added a helper `_resolve_console_script()` in `tests/smoke/test_smoke.py` that tries `shutil.which("jarvis-operator")` and falls back to the active Python scripts directory (`Path(sys.executable).parent`) including a Windows `.exe` candidate, and replaced direct `shutil.which` calls with this helper.
- Updated `.agent/STATE.json`, `.agent/SUMMARY.md`, and `.agent/NEXT_ACTION.md` to record the fix and validation evidence.

### Testing

- Ran `python -m pip install -e .` and the editable install succeeded.
- Ran `python -m pytest tests/smoke/test_smoke.py` and all smoke tests passed (`3 passed`).
- Ran `python -m pytest tests` and the full test suite passed (`86 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb5f309ad083319beba9a8c662db61)